### PR TITLE
rework port and implement pipeline packages

### DIFF
--- a/common/allocator.go
+++ b/common/allocator.go
@@ -146,3 +146,14 @@ type Transformer interface {
 	// implementation may choose an allocator at its will.
 	Transform(Allocator) (unsafe.Pointer, func(unsafe.Pointer))
 }
+
+// TransformPOD allocates a copy of an object pointed to by ptr and
+// returns a pointer to the copy and its destructor.
+func TransformPOD(a Allocator, ptr interface{}) (unsafe.Pointer, func(unsafe.Pointer)) {
+	v := reflect.ValueOf(ptr)
+	t := v.Type().Elem()
+	p := a.Malloc(t.Size())
+	newPtr := reflect.NewAt(t, p)
+	reflect.Indirect(newPtr).Set(v.Elem())
+	return p, a.Free
+}

--- a/common/allocator.go
+++ b/common/allocator.go
@@ -130,3 +130,19 @@ func CString(a Allocator, s string) *C.char {
 	dst[len(s)] = 0
 	return (*C.char)(p)
 }
+
+// Transformer is an object that can recreate some representation of
+// itself allocating memory from Allocator.
+type Transformer interface {
+	// Transform allocates itself from Allocator and returns pointer
+	// to the allocation along with destructor function. Use should
+	// call destructor upon allocated object to avoid memory leak,
+	// e.g.:
+	//   alloc := &common.StdAlloc{}
+	//   x, dtor := obj.Transform(alloc)
+	//   defer dtor(x)
+	//
+	// Implementations may use Allocator as a hint. If it is nil the
+	// implementation may choose an allocator at its will.
+	Transform(Allocator) (unsafe.Pointer, func(unsafe.Pointer))
+}

--- a/common/allocator_test.go
+++ b/common/allocator_test.go
@@ -73,3 +73,19 @@ func TestAllocatorSessionCalloc2(t *testing.T) {
 	assert(p[1] == 456)
 	assert(sh.Data == uintptr(unsafe.Pointer(ptr)))
 }
+
+func TestTransformPOD(t *testing.T) {
+	assert := Assert(t, true)
+
+	type myType struct {
+		X, Y int
+	}
+
+	x := &myType{1, 2}
+	alloc := &StdAlloc{}
+	ptr, dtor := TransformPOD(alloc, x)
+	defer dtor(ptr)
+
+	y := (*myType)(ptr)
+	assert(*x == *y)
+}

--- a/common/common.go
+++ b/common/common.go
@@ -26,6 +26,11 @@ var (
 	ErrSecondary = errors.New("Operation not allowed in secondary processes")
 )
 
+// IntErr returns errno as error.
+func IntErr(n int64) error {
+	return errno(n)
+}
+
 func errno(n int64) error {
 	if n == 0 {
 		return nil

--- a/pipeline/pipeline.go
+++ b/pipeline/pipeline.go
@@ -1,0 +1,121 @@
+// Package pipeline wraps RTE Pipeline.
+//
+// This tool is part of the DPDK Packet Framework tool suite and
+//provides a standard methodology (logically similar to OpenFlow) for
+// rapid development of complex packet processing pipelines out of
+//ports, tables and actions.
+//
+//Basic operation. A pipeline is constructed by connecting its input
+// ports to its output ports through a chain of lookup tables. As
+//result of lookup operation into the current table, one of the table
+// entries (or the default table entry, in case of lookup miss) is
+// identified to provide the actions to be executed on the current
+// packet and the associated action meta-data. The behavior of user
+// actions is defined through the configurable table action handler,
+// while the reserved actions define the next hop for the current
+// packet (either another table, an output port or packet drop) and
+// are handled transparently by the framework.
+//
+// Initialization and run-time flows. Once all the pipeline elements
+// (input ports, tables, output ports) have been created, input ports
+// connected to tables, table action handlers configured, tables
+// populated with the initial set of entries (actions and action
+// meta-data) and input ports enabled, the pipeline runs
+// automatically, pushing packets from input ports to tables and
+// output ports. At each table, the identified user actions are being
+// executed, resulting in action meta-data (stored in the table entry)
+// and packet meta-data (stored with the packet descriptor) being
+// updated. The pipeline tables can have further updates and input
+// ports can be disabled or enabled later on as required.
+//
+// Multi-core scaling. Typically, each CPU core will run its own
+// pipeline instance. Complex application-level pipelines can be
+// implemented by interconnecting multiple CPU core-level pipelines in
+// tree-like topologies, as the same port devices (e.g. SW rings) can
+// serve as output ports for the pipeline running on CPU core A, as
+// well as input ports for the pipeline running on CPU core B. This
+// approach enables the application development using the pipeline
+// (CPU cores connected serially), cluster/run-to-completion (CPU
+// cores connected in parallel) or mixed (pipeline of CPU core
+// clusters) programming models.
+//
+// Thread safety. It is possible to have multiple pipelines running on
+// the same CPU core, but it is not allowed (for thread safety
+// reasons) to have multiple CPU cores running the same pipeline
+// instance.
+package pipeline
+
+/*
+#cgo pkg-config: libdpdk
+#include <rte_pipeline.h>
+*/
+import "C"
+import (
+	"unsafe"
+
+	"github.com/yerden/go-dpdk/common"
+)
+
+// Params configures the pipeline.
+type Params struct {
+	// Name of the pipeline.
+	Name string
+
+	// SocketID for memory allocation.
+	SocketID int
+
+	// Offset within packet meta-data to port_id to be used by action
+	// "Send packet to output port read from packet meta-data". Has to
+	// be 4-byte aligned.
+	OffsetPortID uint32
+}
+
+// Transform implements common.Transformer interface.
+func (p *Params) Transform(alloc common.Allocator) (unsafe.Pointer, func(unsafe.Pointer)) {
+	var params *C.struct_rte_pipeline_params
+	params = (*C.struct_rte_pipeline_params)(alloc.Malloc(unsafe.Sizeof(*params)))
+
+	params.name = (*C.char)(common.CString(alloc, p.Name))
+	params.socket_id = C.int(p.SocketID)
+	params.offset_port_id = C.uint(p.OffsetPortID)
+
+	return unsafe.Pointer(params), func(p unsafe.Pointer) {
+		params := (*C.struct_rte_pipeline_params)(p)
+		alloc.Free(unsafe.Pointer(params.name))
+		alloc.Free(p)
+	}
+}
+
+// Pipeline object.
+type Pipeline C.struct_rte_pipeline
+
+var alloc = &common.StdAlloc{}
+
+// Create pipeline with specified configuration.
+//
+// Returns nil in case of an error.
+func Create(p *Params) *Pipeline {
+	arg, dtor := p.Transform(alloc)
+	defer dtor(arg)
+	return (*Pipeline)(C.rte_pipeline_create((*C.struct_rte_pipeline_params)(arg)))
+}
+
+// Free destroys the pipeline.
+func (pl *Pipeline) Free() error {
+	return common.IntErr(int64(C.rte_pipeline_free((*C.struct_rte_pipeline)(pl))))
+}
+
+// Check the consistency of the pipeline.
+func (pl *Pipeline) Check() error {
+	return common.IntErr(int64(C.rte_pipeline_check((*C.struct_rte_pipeline)(pl))))
+}
+
+// Flush the pipeline.
+func (pl *Pipeline) Flush() error {
+	return common.IntErr(int64(C.rte_pipeline_flush((*C.struct_rte_pipeline)(pl))))
+}
+
+// Run the pipeline.
+func (pl *Pipeline) Run() int {
+	return int(C.rte_pipeline_run((*C.struct_rte_pipeline)(pl)))
+}

--- a/pipeline/pipeline_loop.go
+++ b/pipeline/pipeline_loop.go
@@ -1,0 +1,21 @@
+package pipeline
+
+/*
+#include "pipeline_loop.h"
+*/
+import "C"
+import "unsafe"
+
+// RunLoop runs pipeline continuously, flushing it every 'flush'
+// iterations. RunLoop returns if value referenced by 'stop' is set to
+// non-zero value.
+//
+// flush must be power of 2.
+func (pl *Pipeline) RunLoop(flush uint32, stop *uint8) {
+	params := &C.struct_lcore_arg{}
+	params.p = (*C.struct_rte_pipeline)(pl)
+	params.flush = C.uint32_t(flush)
+	params.stop = (*C.uint8_t)(stop)
+
+	C.run_pipeline_loop(unsafe.Pointer(params))
+}

--- a/pipeline/pipeline_loop.h
+++ b/pipeline/pipeline_loop.h
@@ -1,0 +1,31 @@
+#ifndef _PIPELINE_LOOP_H_
+#define _PIPELINE_LOOP_H_
+
+#include <stdint.h>
+#include <rte_pipeline.h>
+
+struct lcore_arg {
+	struct rte_pipeline *p;
+
+	// iterations before calling rte_pipeline_flush()
+	// should be power of 2.
+	uint32_t flush;
+
+	// if not zero then stop the loop.
+	volatile uint8_t *stop;
+};
+
+static int run_pipeline_loop(void *arg)
+{
+	struct lcore_arg *ctx = arg;
+	uint32_t n;
+
+	for (n = 0; !*ctx->stop; n++) {
+		rte_pipeline_run(ctx->p);
+
+		if (ctx->flush && (n & (ctx->flush - 1)) == 0)
+			rte_pipeline_flush(ctx->p);
+	}
+}
+
+#endif				/* _PIPELINE_LOOP_H_ */

--- a/pipeline/pipeline_test.go
+++ b/pipeline/pipeline_test.go
@@ -1,0 +1,159 @@
+package pipeline
+
+import (
+	"testing"
+
+	"golang.org/x/sys/unix"
+
+	"github.com/yerden/go-dpdk/common"
+	"github.com/yerden/go-dpdk/eal"
+	"github.com/yerden/go-dpdk/mempool"
+	"github.com/yerden/go-dpdk/port"
+	"github.com/yerden/go-dpdk/ring"
+	"github.com/yerden/go-dpdk/table"
+)
+
+var initEAL = common.DoOnce(func() error {
+	var set unix.CPUSet
+	err := unix.SchedGetaffinity(0, &set)
+	if err == nil {
+		_, err = eal.Init([]string{"test",
+			"-c", common.NewMap(&set).String(),
+			"-m", "128",
+			"--no-huge",
+			"--no-pci",
+			"--main-lcore", "0"})
+	}
+	return err
+})
+
+func TestPortRingRx(t *testing.T) {
+	assert := common.Assert(t, true)
+
+	// Initialize EAL on all cores
+	assert(initEAL() == nil)
+
+	err := eal.ExecOnMain(func(*eal.LcoreCtx) {
+		pl := Create(&Params{
+			Name:         "test_pipeline",
+			SocketID:     0,
+			OffsetPortID: 0,
+		})
+		assert(pl != nil)
+
+		mp, err := mempool.CreateMbufPool(
+			"hello",
+			1024,
+			2048,
+		)
+		assert(err == nil, err)
+
+		pSource1, err := pl.PortInCreate(&PortInParams{
+			Params: &port.Source{
+				Mempool: mp,
+			},
+			BurstSize: 32,
+		})
+
+		assert(err == nil, err)
+
+		table1, err := pl.TableCreate(&TableParams{
+			Params: &table.ArrayParams{
+				Entries: 16,
+			},
+		})
+		assert(err == nil, err)
+
+		err = pl.ConnectToTable(pSource1, table1)
+		assert(err == nil, err)
+
+		pSink1, err := pl.PortOutCreate(&PortOutParams{
+			Params: &port.Sink{
+				Filename:   "/dev/null",
+				MaxPackets: 32,
+			},
+		})
+
+		assert(pSink1 == 0)
+		assert(nil == err, err)
+
+		// sample entry
+		entry := &TableEntry{}
+		entry.SetAction(ActionPort)
+		entry.SetPortID(pSink1)
+
+		dfltEntry, err := pl.TableDefaultEntryAdd(table1, entry)
+		assert(err == nil, err)
+		assert(*dfltEntry == *entry)
+
+		assert(nil == pl.Check())
+		assert(nil == pl.Disable(pSource1))
+		assert(nil == pl.Flush())
+
+		// destroy the tables, ports and pipeline
+		assert(nil == pl.Free())
+	})
+	assert(err == nil, err)
+}
+
+func TestPipelineStub(t *testing.T) {
+	assert := common.Assert(t, true)
+
+	// Initialize EAL on all cores
+	assert(initEAL() == nil)
+
+	err := eal.ExecOnMain(func(*eal.LcoreCtx) {
+		pl := Create(&Params{
+			Name:         "test_pipeline",
+			SocketID:     0,
+			OffsetPortID: 0,
+		})
+		assert(pl != nil)
+
+		r, err := ring.Create("test_ring", 1024, ring.OptSC)
+		assert(err == nil, err)
+		assert(r != nil)
+		defer r.Free()
+
+		// create pipeline ports
+		pRing, err := pl.PortInCreate(&PortInParams{
+			Params:    &port.RingRx{Ring: r, Multi: false},
+			BurstSize: 32,
+		})
+		assert(err == nil, err)
+
+		pSink1, err := pl.PortOutCreate(&PortOutParams{
+			Params: &port.Sink{
+				Filename:   "/dev/null",
+				MaxPackets: 32,
+			},
+		})
+
+		assert(pSink1 == 0)
+		assert(nil == err, err)
+
+		// create pipeline tables
+		tStub, err := pl.TableCreate(&TableParams{
+			Params: &table.StubParams{},
+		})
+		assert(err == nil, err)
+
+		entry := NewTableEntry(0)
+		entry.SetAction(2) // C.RTE_PIPELINE_ACTION_PORT_META
+		defaultEntry, err := pl.TableDefaultEntryAdd(tStub, entry)
+		assert(err == nil, err)
+		assert(*defaultEntry == *entry)
+
+		// connect input port.
+		err = pl.ConnectToTable(pRing, tStub)
+		assert(err == nil, err)
+
+		// check the pipeline
+		assert(nil == pl.Check())
+		assert(nil == pl.Flush())
+
+		// destroy the tables, ports and pipeline
+		assert(nil == pl.Free())
+	})
+	assert(err == nil, err)
+}

--- a/pipeline/port.go
+++ b/pipeline/port.go
@@ -1,0 +1,129 @@
+package pipeline
+
+/*
+#include <rte_pipeline.h>
+*/
+import "C"
+
+import (
+	"unsafe"
+
+	"github.com/yerden/go-dpdk/common"
+	"github.com/yerden/go-dpdk/port"
+)
+
+// PortIn represents an input port created in a pipeline.
+type PortIn C.uint32_t
+
+// PortOut represents an output port created in a pipeline.
+type PortOut C.uint32_t
+
+// PortInAction is the pipeline input port action handler.
+//
+// The action handler can decide to drop packets by resetting the
+// associated packet bit in the pkts_mask parameter. In this case, the
+// action handler is required not to free the packet buffer, which
+// will be freed eventually by the pipeline.
+type PortInAction C.rte_pipeline_port_in_action_handler
+
+// PortOutAction is the pipeline output port action handler.
+//
+// The action handler can decide to drop packets by resetting the
+// associated packet bit in the pkts_mask parameter. In this case, the
+// action handler is required not to free the packet buffer, which
+// will be freed eventually by the pipeline.
+type PortOutAction C.rte_pipeline_port_out_action_handler
+
+// PortInParams configures input port creation for pipeline.
+type PortInParams struct {
+	// Port configuration. See port package.
+	Params port.InParams
+
+	// Input port action. Implemented in C.
+	Action PortInAction
+	// Input port action argument.
+	ActionArg unsafe.Pointer
+
+	// Amount of packet burst.
+	BurstSize int
+}
+
+// PortOutParams configures output port creation for pipeline.
+type PortOutParams struct {
+	// Port configuration. See port package.
+	Params port.OutParams
+
+	// Output port action. Implemented in C.
+	Action PortOutAction
+	// Output port action argument.
+	ActionArg unsafe.Pointer
+}
+
+// PortInCreate creates new input port in the pipeline with specified
+// configuration. Returns id of the created port or an error.
+func (pl *Pipeline) PortInCreate(p *PortInParams) (id PortIn, err error) {
+	params := &C.struct_rte_pipeline_port_in_params{}
+	params.ops = (*C.struct_rte_port_in_ops)(unsafe.Pointer(p.Params.InOps()))
+
+	{
+		x, dtor := p.Params.Transform(alloc)
+		defer dtor(x)
+		params.arg_create = x
+	}
+
+	params.f_action = (C.rte_pipeline_port_in_action_handler)(p.Action)
+	params.arg_ah = p.ActionArg
+	params.burst_size = C.uint(p.BurstSize)
+
+	rc := C.rte_pipeline_port_in_create(
+		(*C.struct_rte_pipeline)(pl),
+		params,
+		(*C.uint32_t)(&id))
+
+	return id, common.IntErr(int64(rc))
+}
+
+// PortOutCreate creates new output port in the pipeline with specified
+// configuration. Returns id of the created port or an error.
+func (pl *Pipeline) PortOutCreate(p *PortOutParams) (id PortOut, err error) {
+	params := &C.struct_rte_pipeline_port_out_params{}
+	params.ops = (*C.struct_rte_port_out_ops)(unsafe.Pointer(p.Params.OutOps()))
+
+	{
+		x, dtor := p.Params.Transform(alloc)
+		defer dtor(x)
+		params.arg_create = x
+	}
+
+	params.f_action = (C.rte_pipeline_port_out_action_handler)(p.Action)
+	params.arg_ah = p.ActionArg
+
+	rc := C.rte_pipeline_port_out_create(
+		(*C.struct_rte_pipeline)(pl),
+		params,
+		(*C.uint32_t)(&id))
+
+	return id, common.IntErr(int64(rc))
+}
+
+// ConnectToTable connects specified portID to created tableID.
+func (pl *Pipeline) ConnectToTable(port PortIn, table Table) error {
+	return common.IntErr(int64(C.rte_pipeline_port_in_connect_to_table(
+		(*C.struct_rte_pipeline)(pl),
+		C.uint32_t(port),
+		C.uint32_t(table))))
+}
+
+// Disable input port in the pipeline.
+func (pl *Pipeline) Disable(port PortIn) error {
+	return common.IntErr(int64(C.rte_pipeline_port_in_disable(
+		(*C.struct_rte_pipeline)(pl),
+		C.uint32_t(port))))
+}
+
+// Enable input port in the pipeline.
+func (pl *Pipeline) Enable(port PortIn) error {
+	return common.IntErr(int64(C.rte_pipeline_port_in_enable(
+		(*C.struct_rte_pipeline)(pl),
+		C.uint32_t(port))))
+}

--- a/pipeline/stats.go
+++ b/pipeline/stats.go
@@ -1,0 +1,99 @@
+package pipeline
+
+/*
+#include <rte_pipeline.h>
+*/
+import "C"
+
+import (
+	"unsafe"
+
+	"github.com/yerden/go-dpdk/common"
+	"github.com/yerden/go-dpdk/port"
+	"github.com/yerden/go-dpdk/table"
+)
+
+// PortInStats is the pipeline input port stats.
+type PortInStats struct {
+	port.InStats
+
+	// Number of packets dropped by action handler.
+	PacketsDroppedByAH uint64
+}
+
+// PortOutStats is the pipeline output port stats.
+type PortOutStats struct {
+	port.OutStats
+
+	// Number of packets dropped by action handler.
+	PacketsDroppedByAH uint64
+}
+
+// TableStats is the pipeline table stats.
+type TableStats struct {
+	table.Stats
+
+	PacketsDroppedByHitAH  uint64
+	PacketsDroppedByMissAH uint64
+	PacketsDroppedByHit    uint64
+	PacketsDroppedByMiss   uint64
+}
+
+var _ = []uintptr{
+	unsafe.Sizeof(PortInStats{}) - unsafe.Sizeof(C.struct_rte_pipeline_port_in_stats{}),
+	unsafe.Sizeof(C.struct_rte_pipeline_port_in_stats{}) - unsafe.Sizeof(PortInStats{}),
+	unsafe.Sizeof(PortOutStats{}) - unsafe.Sizeof(C.struct_rte_pipeline_port_out_stats{}),
+	unsafe.Sizeof(C.struct_rte_pipeline_port_out_stats{}) - unsafe.Sizeof(PortOutStats{}),
+	unsafe.Sizeof(TableStats{}) - unsafe.Sizeof(C.struct_rte_pipeline_table_stats{}),
+	unsafe.Sizeof(C.struct_rte_pipeline_table_stats{}) - unsafe.Sizeof(TableStats{}),
+}
+
+// PortOutStatsRead reads stats on output port registered in the
+// pipeline.
+//
+// If clear s true then clear stats after reading.
+func (pl *Pipeline) PortOutStatsRead(port PortOut, s *PortOutStats, clear bool) error {
+	var c C.int
+	if clear {
+		c = 1
+	}
+
+	return common.IntErr(int64(C.rte_pipeline_port_out_stats_read(
+		(*C.struct_rte_pipeline)(pl),
+		C.uint32_t(port),
+		(*C.struct_rte_pipeline_port_out_stats)(unsafe.Pointer(s)),
+		c)))
+}
+
+// PortInStatsRead reads stats on input port registered in the
+// pipeline.
+//
+// If clear s true then clear stats after reading.
+func (pl *Pipeline) PortInStatsRead(port PortIn, s *PortInStats, clear bool) error {
+	var c C.int
+	if clear {
+		c = 1
+	}
+
+	return common.IntErr(int64(C.rte_pipeline_port_in_stats_read(
+		(*C.struct_rte_pipeline)(pl),
+		C.uint32_t(port),
+		(*C.struct_rte_pipeline_port_in_stats)(unsafe.Pointer(s)),
+		c)))
+}
+
+// TableStatsRead reads stats on table registered in the pipeline.
+//
+// If clear s true then clear stats after reading.
+func (pl *Pipeline) TableStatsRead(table Table, s *TableStats, clear bool) error {
+	var c C.int
+	if clear {
+		c = 1
+	}
+
+	return common.IntErr(int64(C.rte_pipeline_table_stats_read(
+		(*C.struct_rte_pipeline)(pl),
+		C.uint32_t(table),
+		(*C.struct_rte_pipeline_table_stats)(unsafe.Pointer(s)),
+		c)))
+}

--- a/pipeline/table.go
+++ b/pipeline/table.go
@@ -1,0 +1,184 @@
+package pipeline
+
+/*
+#include <rte_pipeline.h>
+
+enum {
+	TABLE_ENTRY_PORT_ID = offsetof(struct rte_pipeline_table_entry, port_id),
+	TABLE_ENTRY_TABLE_ID = offsetof(struct rte_pipeline_table_entry, table_id),
+	TABLE_ENTRY_ACTION_DATA = offsetof(struct rte_pipeline_table_entry, action_data[0]),
+};
+
+*/
+import "C"
+import (
+	"unsafe"
+
+	"github.com/yerden/go-dpdk/common"
+	"github.com/yerden/go-dpdk/table"
+)
+
+// Table represents created table in a pipeline.
+type Table C.uint32_t
+
+// TableActionHitFunc is executed on the hit in table.
+type TableActionHitFunc C.rte_pipeline_table_action_handler_hit
+
+// TableActionMissFunc is executed on the miss in table.
+type TableActionMissFunc C.rte_pipeline_table_action_handler_miss
+
+// TableEntry specifies the entry in table.
+type TableEntry C.struct_rte_pipeline_table_entry
+
+// TableParams configures table creation in the pipeline.
+type TableParams struct {
+	Params table.Params
+
+	// OnHit and OnMiss action handlers must be implemented in C.
+	OnHit  TableActionHitFunc
+	OnMiss TableActionMissFunc
+
+	// Argument for OnHit/OnMiss action handlers.
+	ActionArg unsafe.Pointer
+
+	// ActionDataSize specifies size of action data in an entry.
+	ActionDataSize uintptr
+}
+
+// Action specifies what to do with packets on table output.
+type Action uint32
+
+// Reserved actions.
+const (
+	ActionDrop     Action = C.RTE_PIPELINE_ACTION_DROP
+	ActionPort     Action = C.RTE_PIPELINE_ACTION_PORT
+	ActionPortMeta Action = C.RTE_PIPELINE_ACTION_PORT_META
+	ActionTable    Action = C.RTE_PIPELINE_ACTION_TABLE
+)
+
+// SetAction sets configured action in the entry.
+func (entry *TableEntry) SetAction(code Action) {
+	entry.action = uint32(code)
+}
+
+// GetAction returns configured action in the entry.
+func (entry *TableEntry) GetAction() (code uint32) {
+	return entry.action
+}
+
+// SetPortID sets configured output port ID (meta-data for "Send
+// packet to output port" action).
+func (entry *TableEntry) SetPortID(port PortOut) {
+	p := (*PortOut)(unsafe.Add(unsafe.Pointer(entry), C.TABLE_ENTRY_PORT_ID))
+	*p = port
+}
+
+// GetPortID returns configured output port ID (meta-data for "Send
+// packet to output port" action).
+func (entry *TableEntry) GetPortID() (port PortOut) {
+	p := (*PortOut)(unsafe.Add(unsafe.Pointer(entry), C.TABLE_ENTRY_PORT_ID))
+	return *p
+}
+
+// SetTableID sets configured table in the entry for "Send packet to
+// table" action.
+func (entry *TableEntry) SetTableID(table Table) {
+	p := (*Table)(unsafe.Add(unsafe.Pointer(entry), C.TABLE_ENTRY_TABLE_ID))
+	*p = table
+}
+
+// GetTableID returns configured table in the entry for "Send packet
+// to table" action.
+func (entry *TableEntry) GetTableID() Table {
+	p := (*Table)(unsafe.Add(unsafe.Pointer(entry), C.TABLE_ENTRY_TABLE_ID))
+	return *p
+}
+
+// GetActionData returns pointer to action user data.
+func (entry *TableEntry) GetActionData() unsafe.Pointer {
+	return unsafe.Add(unsafe.Pointer(entry), C.TABLE_ENTRY_ACTION_DATA)
+}
+
+// TableCreate creates new table in the pipeline.
+func (pl *Pipeline) TableCreate(p *TableParams) (id Table, err error) {
+	params := &C.struct_rte_pipeline_table_params{}
+	params.ops = (*C.struct_rte_table_ops)(unsafe.Pointer(p.Params.Ops()))
+
+	{
+		x, dtor := p.Params.Transform(alloc)
+		defer dtor(x)
+		params.arg_create = x
+	}
+
+	params.f_action_hit = (C.rte_pipeline_table_action_handler_hit)(p.OnHit)
+	params.f_action_miss = (C.rte_pipeline_table_action_handler_miss)(p.OnMiss)
+	params.arg_ah = p.ActionArg
+
+	params.action_data_size = C.uint(p.ActionDataSize)
+
+	rc := C.rte_pipeline_table_create(
+		(*C.struct_rte_pipeline)(pl),
+		params,
+		(*C.uint32_t)(&id))
+
+	return id, common.IntErr(int64(rc))
+}
+
+// NewTableEntry creates new table entry template allocated in Go. Use
+// actionDataSize as specified during table creation.
+func NewTableEntry(actionDataSize uintptr) *TableEntry {
+	b := make([]byte, unsafe.Sizeof(TableEntry{})+actionDataSize)
+	return (*TableEntry)(unsafe.Pointer(&b[0]))
+}
+
+// TableDefaultEntryAdd adds default entry to table in the pipeline.
+// Returns pointer to actual TableEntry instance in the pipeline's
+// table.
+func (pl *Pipeline) TableDefaultEntryAdd(table Table, entry *TableEntry) (*TableEntry, error) {
+	var p *C.struct_rte_pipeline_table_entry
+	rc := C.rte_pipeline_table_default_entry_add((*C.struct_rte_pipeline)(pl), C.uint32_t(table), (*C.struct_rte_pipeline_table_entry)(entry), &p)
+	return (*TableEntry)(p), common.IntErr(int64(rc))
+}
+
+// TableDefaultEntryDelete deletes default entry from table in the pipeline.
+// entry then is filled with removed entry.
+func (pl *Pipeline) TableDefaultEntryDelete(table Table, entry *TableEntry) error {
+	rc := C.rte_pipeline_table_default_entry_delete((*C.struct_rte_pipeline)(pl), C.uint32_t(table), (*C.struct_rte_pipeline_table_entry)(entry))
+	return common.IntErr(int64(rc))
+}
+
+// TableEntryAdd adds key/entry into table. On successful invocation,
+// ptrEntry points to found entry. Returns true of entry was present
+// in the map prior to invocation.
+//
+// pkey is table-specific pointer to a struct containing a key. Please
+// refer to table's API for key specification.
+func (pl *Pipeline) TableEntryAdd(table Table, pkey unsafe.Pointer, entry *TableEntry, ptrEntry **TableEntry) (bool, error) {
+	var found C.int
+
+	rc := C.rte_pipeline_table_entry_add(
+		(*C.struct_rte_pipeline)(pl),
+		C.uint32_t(table),
+		pkey,
+		(*C.struct_rte_pipeline_table_entry)(entry),
+		&found,
+		(**C.struct_rte_pipeline_table_entry)(unsafe.Pointer(ptrEntry)))
+	return found != 0, common.IntErr(int64(rc))
+}
+
+// TableEntryDelete removes key from table. entry is filled with
+// removed entry.
+//
+// pkey is table-specific pointer to a struct containing a key. Please
+// refer to table's API for key specification.
+func (pl *Pipeline) TableEntryDelete(table Table, pkey unsafe.Pointer, entry *TableEntry) (bool, error) {
+	var found C.int
+
+	rc := C.rte_pipeline_table_entry_delete(
+		(*C.struct_rte_pipeline)(pl),
+		C.uint32_t(table),
+		pkey,
+		&found,
+		(*C.struct_rte_pipeline_table_entry)(entry))
+	return found != 0, common.IntErr(int64(rc))
+}

--- a/port/cgo_shared.go
+++ b/port/cgo_shared.go
@@ -1,3 +1,9 @@
+/*
+Package port wraps RTE Port.
+
+This tool is part of the DPDK Packet Framework tool suite and provides
+a standard interface to implement different types of packet ports.
+*/
 package port
 
 /*

--- a/port/stats.go
+++ b/port/stats.go
@@ -1,0 +1,27 @@
+package port
+
+/*
+#include <rte_port.h>
+*/
+import "C"
+import (
+	"unsafe"
+)
+
+// InStats is an input port statistics.
+type InStats struct {
+	PacketsIn   uint64
+	PacketsDrop uint64
+}
+
+var _ uintptr = unsafe.Sizeof(InStats{}) - unsafe.Sizeof(C.struct_rte_port_in_stats{})
+var _ uintptr = unsafe.Sizeof(C.struct_rte_port_in_stats{}) - unsafe.Sizeof(InStats{})
+
+// OutStats is an output port statistics.
+type OutStats struct {
+	PacketsIn   uint64
+	PacketsDrop uint64
+}
+
+var _ uintptr = unsafe.Sizeof(OutStats{}) - unsafe.Sizeof(C.struct_rte_port_out_stats{})
+var _ uintptr = unsafe.Sizeof(C.struct_rte_port_out_stats{}) - unsafe.Sizeof(OutStats{})

--- a/table/acl.go
+++ b/table/acl.go
@@ -1,0 +1,74 @@
+package table
+
+/*
+#include <rte_table.h>
+#include <rte_table_acl.h>
+*/
+import "C"
+
+import (
+	"unsafe"
+
+	"github.com/yerden/go-dpdk/common"
+)
+
+// ACLFieldDef is the ACL Field definition. Each field in the ACL rule
+// has an associate definition. It defines the type of field, its
+// size, its offset in the input buffer, the field index, and the
+// input index. For performance reasons, the inner loop of the search
+// function is unrolled to process four input bytes at a time. This
+// requires the input to be grouped into sets of 4 consecutive bytes.
+// The loop processes the first input byte as part of the setup and
+// then subsequent bytes must be in groups of 4 consecutive bytes.
+type ACLFieldDef struct {
+	Type       uint8  // type - RTE_ACL_FIELD_TYPE_*.
+	Size       uint8  // size of field 1,2,4, or 8.
+	FieldIndex uint8  // index of field inside the rule.
+	InputIndex uint8  // 0-N input index.
+	Offset     uint32 // offset to start of field.
+}
+
+// ACLParams is the ACL table parameters.
+type ACLParams struct {
+	Name        string        // Name.
+	Rules       uint32        // Maximum number of ACL rules in the table.
+	FieldFormat []ACLFieldDef // Format specification of the fields of the ACL rule.
+}
+
+var _ Params = (*ACLParams)(nil)
+
+// Ops implements Params interface.
+func (p *ACLParams) Ops() *Ops {
+	return (*Ops)(&C.rte_table_acl_ops)
+}
+
+var alloc = &common.StdAlloc{}
+
+// Transform implements common.Transformer interface.
+func (p *ACLParams) Transform(alloc common.Allocator) (unsafe.Pointer, func(unsafe.Pointer)) {
+	var params *C.struct_rte_table_acl_params
+	params = (*C.struct_rte_table_acl_params)(alloc.Malloc(unsafe.Sizeof(*params)))
+
+	if len(p.FieldFormat) > len(params.field_format) {
+		panic("excessive field format entries in ACL params")
+	}
+
+	params.name = (*C.char)(common.CString(alloc, p.Name))
+	params.n_rules = C.uint(p.Rules)
+	params.n_rule_fields = C.uint(len(p.FieldFormat))
+	for i := range p.FieldFormat {
+		src := &p.FieldFormat[i]
+		dst := &params.field_format[i]
+		dst._type = C.uint8_t(src.Type)
+		dst.size = C.uint8_t(src.Size)
+		dst.field_index = C.uint8_t(src.FieldIndex)
+		dst.input_index = C.uint8_t(src.InputIndex)
+		dst.offset = C.uint32_t(src.Offset)
+	}
+
+	return unsafe.Pointer(params), func(p unsafe.Pointer) {
+		params := (*C.struct_rte_table_acl_params)(p)
+		alloc.Free(unsafe.Pointer(params.name))
+		alloc.Free(unsafe.Pointer(params))
+	}
+}

--- a/table/acl_params.go
+++ b/table/acl_params.go
@@ -1,0 +1,79 @@
+package table
+
+/*
+#include <rte_table_acl.h>
+
+enum {
+	ACL_FIELD_DIM_64 = sizeof(struct rte_acl_field) / sizeof(uint64_t),
+};
+
+*/
+import "C"
+
+import (
+	"unsafe"
+)
+
+// ACLField describes a field to match.
+type ACLField [C.ACL_FIELD_DIM_64]uint64
+type cACLField C.struct_rte_acl_field
+
+// NewACLField8 returns ACLField with 8-bit value and range mask.
+func NewACLField8(value, maskRange uint8) ACLField {
+	var ret ACLField
+	dst := (*C.struct_rte_acl_field)(unsafe.Pointer(&ret))
+	*(*uint8)(unsafe.Pointer(&dst.value)) = value
+	*(*uint8)(unsafe.Pointer(&dst.mask_range)) = maskRange
+	return ret
+}
+
+// NewACLField16 returns ACLField with 16-bit value and range mask.
+func NewACLField16(value, maskRange uint16) ACLField {
+	var ret ACLField
+	dst := (*C.struct_rte_acl_field)(unsafe.Pointer(&ret))
+	*(*uint16)(unsafe.Pointer(&dst.value)) = value
+	*(*uint16)(unsafe.Pointer(&dst.mask_range)) = maskRange
+	return ret
+}
+
+// NewACLField32 returns ACLField with 32-bit value and range mask.
+func NewACLField32(value, maskRange uint32) ACLField {
+	var ret ACLField
+	dst := (*C.struct_rte_acl_field)(unsafe.Pointer(&ret))
+	*(*uint32)(unsafe.Pointer(&dst.value)) = value
+	*(*uint32)(unsafe.Pointer(&dst.mask_range)) = maskRange
+	return ret
+}
+
+// NewACLField64 returns ACLField with 64-bit value and range mask.
+func NewACLField64(value, maskRange uint64) ACLField {
+	var ret ACLField
+	dst := (*C.struct_rte_acl_field)(unsafe.Pointer(&ret))
+	*(*uint64)(unsafe.Pointer(&dst.value)) = value
+	*(*uint64)(unsafe.Pointer(&dst.mask_range)) = maskRange
+	return ret
+}
+
+// ACLRuleAdd is the key for adding a key/value to a table.
+type ACLRuleAdd struct {
+	Priority   int32
+	FieldValue [C.RTE_ACL_MAX_FIELDS]ACLField
+}
+type cACLRuleAdd C.struct_rte_table_acl_rule_add_params
+
+// ACLRuleDelete is the key for deleting a key/value from a table.
+type ACLRuleDelete struct {
+	FieldValue [C.RTE_ACL_MAX_FIELDS]ACLField
+}
+type cACLRuleDelete C.struct_rte_table_acl_rule_delete_params
+
+var _ = []uintptr{
+	unsafe.Sizeof(ACLField{}) - unsafe.Sizeof(cACLField{}),
+	unsafe.Sizeof(cACLField{}) - unsafe.Sizeof(ACLField{}),
+
+	unsafe.Sizeof(ACLRuleAdd{}) - unsafe.Sizeof(cACLRuleAdd{}),
+	unsafe.Sizeof(cACLRuleAdd{}) - unsafe.Sizeof(ACLRuleAdd{}),
+
+	unsafe.Sizeof(ACLRuleDelete{}) - unsafe.Sizeof(cACLRuleDelete{}),
+	unsafe.Sizeof(cACLRuleDelete{}) - unsafe.Sizeof(ACLRuleDelete{}),
+}

--- a/table/array.go
+++ b/table/array.go
@@ -1,0 +1,40 @@
+package table
+
+/*
+#include <rte_table_array.h>
+*/
+import "C"
+
+import (
+	"unsafe"
+
+	"github.com/yerden/go-dpdk/common"
+)
+
+// ArrayParams is the Array table parameters.
+type ArrayParams struct {
+	// Number of array entries. Has to be a power of two.
+	Entries uint32
+
+	// Byte offset within input packet meta-data where lookup key
+	// (i.e. the array entry index) is located.
+	Offset uint32
+}
+
+// Transform implements common.Transformer interface.
+func (p *ArrayParams) Transform(alloc common.Allocator) (unsafe.Pointer, func(unsafe.Pointer)) {
+	return common.TransformPOD(alloc, &C.struct_rte_table_array_params{
+		n_entries: C.uint32_t(p.Entries),
+		offset:    C.uint32_t(p.Offset),
+	})
+}
+
+// Ops implements Params interface.
+func (p *ArrayParams) Ops() *Ops {
+	return (*Ops)(&C.rte_table_array_ops)
+}
+
+// ArrayKey is the key for adding/deleting key from table.
+type ArrayKey struct {
+	Pos uint32
+}

--- a/table/hash.go
+++ b/table/hash.go
@@ -1,0 +1,131 @@
+package table
+
+/*
+#include <rte_hash.h>
+#include <rte_hash_crc.h>
+#include <rte_table_hash.h>
+#include <rte_table_hash_cuckoo.h>
+
+rte_hash_function go_crc32f = rte_hash_crc;
+
+*/
+import "C"
+
+import (
+	"unsafe"
+
+	"github.com/yerden/go-dpdk/common"
+)
+
+var (
+	// Crc32Hash is the DPDK CRC32 hash function.
+	Crc32Hash HashFunc = (HashFunc)(C.go_crc32f)
+)
+
+// HashOpHash is the signature of hash function used for Hash table
+// implementation.
+type HashOpHash C.rte_table_hash_op_hash
+
+// HashFunc is the signature of hash function used for Cuckoo-Hash
+// table implementation.
+type HashFunc C.rte_hash_function
+
+// Table ops implementations.
+var (
+	HashExtOps    = (*Ops)(&C.rte_table_hash_ext_ops)
+	HashLruOps    = (*Ops)(&C.rte_table_hash_lru_ops)
+	HashCuckooOps = (*Ops)(&C.rte_table_hash_cuckoo_ops)
+)
+
+// HashParams is the Hash table parameters.
+type HashParams struct {
+	// Set this to desired Hash*Ops variable.
+	TableOps *Ops
+
+	// Name.
+	Name string
+
+	// Key size (number of bytes).
+	KeySize uint32
+
+	// Byte offset within packet meta-data where the key is located
+	KeyOffset uint32
+
+	// Key mask.
+	KeyMask []byte
+
+	// Number of keys.
+	KeysNum uint32
+
+	// Number of buckets.
+	BucketsNum uint32
+
+	// Hash function.
+	Hash struct {
+		Func HashOpHash
+		Seed uint64
+	}
+
+	// Hash function for HashCuckooOps.
+	CuckooHash struct {
+		Func HashFunc
+		Seed uint32
+	}
+}
+
+// Transform implements common.Transformer interface.
+func (p *HashParams) Transform(alloc common.Allocator) (unsafe.Pointer, func(unsafe.Pointer)) {
+	switch p.TableOps {
+	case HashExtOps:
+		fallthrough
+	case HashLruOps:
+		return p.tformToOrdinary(alloc)
+	case HashCuckooOps:
+		return p.tformToCuckoo(alloc)
+	}
+
+	panic("unsupported Hash Table ops")
+}
+
+func (p *HashParams) tformToOrdinary(alloc common.Allocator) (unsafe.Pointer, func(unsafe.Pointer)) {
+	var params *C.struct_rte_table_hash_params
+	params = (*C.struct_rte_table_hash_params)(alloc.Malloc(unsafe.Sizeof(*params)))
+	params.name = (*C.char)(common.CString(alloc, p.Name))
+	params.key_size = C.uint32_t(p.KeySize)
+	params.key_offset = C.uint32_t(p.KeyOffset)
+	params.key_mask = (*C.uint8_t)(common.CBytes(alloc, p.KeyMask))
+	params.n_keys = C.uint32_t(p.KeysNum)
+	params.n_buckets = C.uint32_t(p.BucketsNum)
+	params.f_hash = C.rte_table_hash_op_hash(p.Hash.Func)
+	params.seed = C.uint64_t(p.Hash.Seed)
+	return unsafe.Pointer(params), func(p unsafe.Pointer) {
+		params := (*C.struct_rte_table_hash_params)(p)
+		alloc.Free(unsafe.Pointer(params.name))
+		alloc.Free(unsafe.Pointer(params.key_mask))
+		alloc.Free(p)
+	}
+}
+
+func (p *HashParams) tformToCuckoo(alloc common.Allocator) (unsafe.Pointer, func(unsafe.Pointer)) {
+	var params *C.struct_rte_table_hash_cuckoo_params
+	params = (*C.struct_rte_table_hash_cuckoo_params)(alloc.Malloc(unsafe.Sizeof(*params)))
+	params.name = (*C.char)(common.CString(alloc, p.Name))
+	params.key_size = C.uint32_t(p.KeySize)
+	params.key_offset = C.uint32_t(p.KeyOffset)
+	params.key_mask = (*C.uint8_t)(common.CBytes(alloc, p.KeyMask))
+	params.n_keys = C.uint32_t(p.KeysNum)
+	params.n_buckets = C.uint32_t(p.BucketsNum)
+	params.f_hash = C.rte_hash_function(p.CuckooHash.Func)
+	params.seed = C.uint32_t(p.CuckooHash.Seed)
+	return unsafe.Pointer(params), func(p unsafe.Pointer) {
+		params := (*C.struct_rte_table_hash_cuckoo_params)(p)
+		alloc.Free(unsafe.Pointer(params.name))
+		alloc.Free(unsafe.Pointer(params.key_mask))
+		alloc.Free(p)
+	}
+}
+
+// Ops implements Params interface.
+func (p *HashParams) Ops() *Ops {
+	return p.TableOps
+}

--- a/table/lpm.go
+++ b/table/lpm.go
@@ -1,0 +1,125 @@
+package table
+
+/*
+#include <rte_table_lpm.h>
+#include <rte_table_lpm_ipv6.h>
+*/
+import "C"
+
+import (
+	"unsafe"
+
+	"github.com/yerden/go-dpdk/common"
+)
+
+var (
+	// LPMOps is the LPM IPv4 ops.
+	LPMOps = (*Ops)(&C.rte_table_lpm_ops)
+
+	// LPM6Ops is the LPM IPv6 ops.
+	LPM6Ops = (*Ops)(&C.rte_table_lpm_ipv6_ops)
+)
+
+// LPMParams is the Hash table parameters.
+type LPMParams struct {
+	TableOps *Ops
+
+	// Name.
+	Name string
+
+	// Number of rules.
+	Rules uint32
+
+	// Field is currently unused.
+	NumTBL8 uint32
+
+	// Number of bytes at the start of the table entry that uniquely
+	// identify the entry. Cannot be bigger than table entry size.
+	EntryUniqueSize uint32
+
+	// Byte offset within input packet meta-data where lookup key
+	// (i.e. the destination IP address) is located.
+	Offset uint32
+}
+
+// Transform implements common.Transformer interface.
+func (p *LPMParams) Transform(alloc common.Allocator) (unsafe.Pointer, func(unsafe.Pointer)) {
+	switch p.TableOps {
+	case LPMOps:
+		return p.tformTo4(alloc)
+	case LPM6Ops:
+		return p.tformTo6(alloc)
+	}
+
+	panic("unsupported LPM Table ops")
+}
+
+func (p *LPMParams) tformTo4(alloc common.Allocator) (unsafe.Pointer, func(unsafe.Pointer)) {
+	var params *C.struct_rte_table_lpm_params
+	params = (*C.struct_rte_table_lpm_params)(alloc.Malloc(unsafe.Sizeof(*params)))
+	params.name = (*C.char)(common.CString(alloc, p.Name))
+	params.number_tbl8s = C.uint32_t(p.NumTBL8)
+	params.n_rules = C.uint32_t(p.Rules)
+	params.entry_unique_size = C.uint32_t(p.EntryUniqueSize)
+	params.offset = C.uint32_t(p.Offset)
+
+	return unsafe.Pointer(params), func(p unsafe.Pointer) {
+		params := (*C.struct_rte_table_lpm_params)(p)
+		alloc.Free(unsafe.Pointer(params.name))
+		alloc.Free(p)
+	}
+}
+
+func (p *LPMParams) tformTo6(alloc common.Allocator) (unsafe.Pointer, func(unsafe.Pointer)) {
+	var params *C.struct_rte_table_lpm_ipv6_params
+	params = (*C.struct_rte_table_lpm_ipv6_params)(alloc.Malloc(unsafe.Sizeof(*params)))
+	params.name = (*C.char)(common.CString(alloc, p.Name))
+	params.n_rules = C.uint32_t(p.Rules)
+	params.entry_unique_size = C.uint32_t(p.EntryUniqueSize)
+	params.offset = C.uint32_t(p.Offset)
+
+	return unsafe.Pointer(params), func(p unsafe.Pointer) {
+		params := (*C.struct_rte_table_lpm_ipv6_params)(p)
+		alloc.Free(unsafe.Pointer(params.name))
+		alloc.Free(p)
+	}
+}
+
+// LPMKey is the insert key for LPM IPv4 table.
+type LPMKey struct {
+	// IP address.
+	IP uint32
+
+	// IP address depth. The most significant "depth" bits of the IP
+	// address specify the network part of the IP address, while the
+	// rest of the bits specify the host part of the address and are
+	// ignored for the purpose of route specification.
+	Depth uint8
+
+	// padding to fix alignment
+	_ [3]byte
+}
+
+type cLPMKey C.struct_rte_table_lpm_key
+
+// LPM6Key is the insert key for LPM IPv4 table.
+type LPM6Key struct {
+	// IP address.
+	IP [C.RTE_LPM_IPV6_ADDR_SIZE]byte
+
+	// IP address depth. The most significant "depth" bits of the IP
+	// address specify the network part of the IP address, while the
+	// rest of the bits specify the host part of the address and are
+	// ignored for the purpose of route specification.
+	Depth uint8
+}
+
+type cLPM6Key C.struct_rte_table_lpm_ipv6_key
+
+var _ = []uintptr{
+	unsafe.Sizeof(LPMKey{}) - unsafe.Sizeof(cLPMKey{}),
+	unsafe.Sizeof(cLPMKey{}) - unsafe.Sizeof(LPMKey{}),
+
+	unsafe.Sizeof(LPM6Key{}) - unsafe.Sizeof(cLPM6Key{}),
+	unsafe.Sizeof(cLPM6Key{}) - unsafe.Sizeof(LPM6Key{}),
+}

--- a/table/stats.go
+++ b/table/stats.go
@@ -1,0 +1,18 @@
+package table
+
+/*
+#include <rte_table.h>
+*/
+import "C"
+import (
+	"unsafe"
+)
+
+// Stats is a table statistics.
+type Stats struct {
+	PacketsIn         uint64
+	PacketsLookupMiss uint64
+}
+
+var _ uintptr = unsafe.Sizeof(Stats{}) - unsafe.Sizeof(C.struct_rte_table_stats{})
+var _ uintptr = unsafe.Sizeof(C.struct_rte_table_stats{}) - unsafe.Sizeof(Stats{})

--- a/table/stub.go
+++ b/table/stub.go
@@ -1,0 +1,25 @@
+package table
+
+/*
+#include <rte_table_stub.h>
+*/
+import "C"
+
+import (
+	"unsafe"
+
+	"github.com/yerden/go-dpdk/common"
+)
+
+// StubParams is the empty parameters for Stub table.
+type StubParams struct{}
+
+// Transform implements common.Transformer interface.
+func (p *StubParams) Transform(alloc common.Allocator) (unsafe.Pointer, func(unsafe.Pointer)) {
+	return nil, alloc.Free
+}
+
+// Ops implements Params interface.
+func (p *StubParams) Ops() *Ops {
+	return (*Ops)(&C.rte_table_stub_ops)
+}

--- a/table/table.go
+++ b/table/table.go
@@ -1,0 +1,65 @@
+/*
+Package table implements RTE Table.
+
+This tool is part of the DPDK Packet Framework tool suite and provides a
+standard interface to implement different types of lookup tables for data plane
+processing.
+
+Virtually any search algorithm that can uniquely associate data to a lookup key
+can be fitted under this lookup table abstraction. For the flow table use-case,
+the lookup key is an n-tuple of packet fields that uniquely identifies a
+traffic flow, while data represents actions and action meta-data associated
+with the same traffic flow.
+*/
+package table
+
+/*
+#cgo pkg-config: libdpdk
+#include <rte_table.h>
+
+static void *
+go_table_create(struct rte_table_ops *ops, void *params, int socket_id, uint32_t entry_size)
+{
+	return ops->f_create(params, socket_id, entry_size);
+}
+
+static int
+go_table_free(struct rte_table_ops *ops, void *table)
+{
+	return ops->f_free(table);
+}
+
+*/
+import "C"
+import (
+	"unsafe"
+
+	"github.com/yerden/go-dpdk/common"
+)
+
+// Ops is the function table implementing table.
+type Ops C.struct_rte_table_ops
+
+// Table is the instance of a lookup table.
+type Table [0]byte
+
+// Params is the parameters for creating a table.
+type Params interface {
+	common.Transformer
+	Ops() *Ops
+}
+
+// Create a table manually. May return nil pointer in case of an
+// error.
+func Create(socket int, p Params, entrySize uint32) *Table {
+	ops := (*C.struct_rte_table_ops)(p.Ops())
+	arg, dtor := p.Transform(alloc)
+	defer dtor(arg)
+	return (*Table)(C.go_table_create(ops, arg, C.int(socket), C.uint32_t(entrySize)))
+}
+
+// Free deletes a table.
+func (t *Table) Free(tableOps *Ops) error {
+	ops := (*C.struct_rte_table_ops)(tableOps)
+	return common.IntErr(int64(C.go_table_free(ops, unsafe.Pointer(t))))
+}

--- a/table/table_test.go
+++ b/table/table_test.go
@@ -1,0 +1,50 @@
+package table
+
+import (
+	"testing"
+
+	"golang.org/x/sys/unix"
+
+	"github.com/yerden/go-dpdk/common"
+	"github.com/yerden/go-dpdk/eal"
+)
+
+var initEAL = common.DoOnce(func() error {
+	var set unix.CPUSet
+	err := unix.SchedGetaffinity(0, &set)
+	if err == nil {
+		_, err = eal.Init([]string{"test",
+			"-c", common.NewMap(&set).String(),
+			"-m", "128",
+			"--no-huge",
+			"--no-pci",
+			"--main-lcore", "0"})
+	}
+	return err
+})
+
+func TestTableHash(t *testing.T) {
+	assert := common.Assert(t, true)
+
+	// Initialize EAL on all cores
+	assert(initEAL() == nil)
+
+	err := eal.ExecOnMain(func(*eal.LcoreCtx) {
+		hash := &HashParams{
+			TableOps:   HashCuckooOps,
+			Name:       "hello",
+			KeySize:    32,
+			KeysNum:    1024,
+			BucketsNum: 1024,
+		}
+
+		hash.CuckooHash.Func = Crc32Hash
+
+		table1 := Create(0, hash, 20)
+		assert(table1 != nil)
+
+		err := table1.Free(hash.TableOps)
+		assert(err == nil)
+	})
+	assert(err == nil, err)
+}


### PR DESCRIPTION
Changes:

* `port` now uses native C types to allow extension in third-party code;
* implement `table` and `pipeline` packages.