### PR TITLE
redesign ethdev/flow

### DIFF
--- a/app/test-sniffer/util.go
+++ b/app/test-sniffer/util.go
@@ -57,9 +57,9 @@ func rssEthVlanIPv4(pid ethdev.Port, conf *ethdev.RssConf) (*flow.Flow, error) {
 	attr := &flow.Attr{Ingress: true}
 
 	pattern := []flow.Item{
-		{Spec: flow.ItemTypeEth},  // Ethernet
-		{Spec: flow.ItemTypeVlan}, // VLAN
-		{Spec: flow.ItemTypeIPv4}, // IPv4
+		{Spec: &flow.ItemEth{}},  // Ethernet
+		{Spec: &flow.ItemVlan{}}, // VLAN
+		{Spec: &flow.ItemIPv4{}}, // IPv4
 	}
 
 	actions := []flow.Action{
@@ -83,9 +83,9 @@ func mlxRssEthVlanIPv4(pid ethdev.Port, conf *ethdev.RssConf) (*flow.Flow, error
 	attr := &flow.Attr{Ingress: true}
 
 	pattern := []flow.Item{
-		{Spec: flow.ItemTypeEth},  // Ethernet
-		{Spec: flow.ItemTypeVlan}, // VLAN
-		{Spec: flow.ItemTypeIPv4}, // IPv4
+		{Spec: &flow.ItemEth{}},  // Ethernet
+		{Spec: &flow.ItemVlan{}}, // VLAN
+		{Spec: &flow.ItemIPv4{}}, // IPv4
 	}
 
 	var info ethdev.DevInfo

--- a/ethdev/flow/action.go
+++ b/ethdev/flow/action.go
@@ -6,19 +6,12 @@ package flow
 #include <rte_flow.h>
 */
 import "C"
-import "unsafe"
+import (
+	"github.com/yerden/go-dpdk/common"
+)
 
 // ActionType is the rte_flow_action type.
 type ActionType uint32
-
-// Reload implements Action interface.
-func (t ActionType) Reload() {}
-
-// Pointer implements Action interface.
-func (t ActionType) Pointer() unsafe.Pointer { return nil }
-
-// Type implements Action interface.
-func (t ActionType) Type() ActionType { return t }
 
 // Action is the definition of a single action.
 //
@@ -27,13 +20,8 @@ func (t ActionType) Type() ActionType { return t }
 // For simple actions without a configuration object, conf remains
 // NULL.
 type Action interface {
-	// Pointer returns a valid C pointer to underlying struct.
-	Pointer() unsafe.Pointer
+	common.Transformer
 
-	// Reload is used to apply changes so that the underlying struct
-	// reflects the up-to-date configuration.
-	Reload()
-
-	// Type returns implemented rte_flow_action_* struct.
-	Type() ActionType
+	// ActionType returns implemented rte_flow_action_* struct.
+	ActionType() ActionType
 }

--- a/ethdev/flow/flow_test.go
+++ b/ethdev/flow/flow_test.go
@@ -8,13 +8,3 @@ func assert(t testing.TB, expected bool, args ...interface{}) {
 		t.Fatal(args...)
 	}
 }
-
-func TestCPattern(t *testing.T) {
-	pattern := []Item{
-		{Spec: &ItemIPv4{}, Mask: &ItemIPv4{}},
-	}
-
-	pat := cPattern(pattern)
-	assert(t, pat != nil)
-
-}

--- a/ethdev/flow/item.go
+++ b/ethdev/flow/item.go
@@ -6,39 +6,26 @@ package flow
 #include <rte_flow.h>
 */
 import "C"
-import "unsafe"
+import (
+	"unsafe"
+
+	"github.com/yerden/go-dpdk/common"
+)
 
 // ItemType represents rte_flow_item type.
 type ItemType uint32
 
-// Reload implements ItemStruct interface.
-func (t ItemType) Reload() {}
+// ItemValue should be implemented to specify in Item.
+type ItemValue interface {
+	common.Transformer
 
-// Pointer implements ItemStruct interface.
-func (t ItemType) Pointer() unsafe.Pointer { return nil }
-
-// Type implements ItemStruct interface.
-func (t ItemType) Type() ItemType { return t }
-
-// Mask implements ItemStruct interface.
-func (t ItemType) Mask() unsafe.Pointer { return nil }
-
-// ItemStruct should be implemented to specify in Item.
-type ItemStruct interface {
-	// Pointer returns a valid C pointer to underlying struct.
-	Pointer() unsafe.Pointer
-
-	// Reload is used to apply changes so that the underlying struct
-	// reflects the up-to-date configuration.
-	Reload()
-
-	// Type returns implemented rte_flow_item_* struct.
-	Type() ItemType
+	// ItemType returns implemented rte_flow_item_* struct.
+	ItemType() ItemType
 
 	// Mask returns pointer to rte_flow_item_*_mask variables. They
 	// should not be changed by user so Mask returns pointer to C
 	// struct.
-	Mask() unsafe.Pointer
+	DefaultMask() unsafe.Pointer
 }
 
 // Item is the matching pattern item definition.
@@ -77,5 +64,5 @@ type ItemStruct interface {
 // Go: you may also specify ItemType as a Spec field if you don't want
 // to specify any pattern for the item.
 type Item struct {
-	Spec, Last, Mask ItemStruct
+	Spec, Last, Mask ItemValue
 }

--- a/ethdev/flow/item_ipv4.go
+++ b/ethdev/flow/item_ipv4.go
@@ -3,6 +3,7 @@ package flow
 /*
 #include <stdint.h>
 #include <rte_config.h>
+#include <rte_ip.h>
 #include <rte_flow.h>
 
 enum {
@@ -16,8 +17,9 @@ static const struct rte_flow_item_ipv4 *get_item_ipv4_mask() {
 */
 import "C"
 import (
-	"runtime"
 	"unsafe"
+
+	"github.com/yerden/go-dpdk/common"
 )
 
 // IPv4 represents a raw IPv4 address.
@@ -37,50 +39,31 @@ type IPv4Header struct {
 	DstAddr        IPv4   /* Destination address. */
 }
 
+const _ uintptr = unsafe.Sizeof(IPv4Header{}) - C.sizeof_struct_rte_ipv4_hdr
+const _ uintptr = C.sizeof_struct_rte_ipv4_hdr - unsafe.Sizeof(IPv4Header{})
+
 // ItemIPv4 matches an IPv4 header.
 //
 // Note: IPv4 options are handled by dedicated pattern items.
 type ItemIPv4 struct {
-	cPointer
-
 	Header IPv4Header
 }
 
-var _ ItemStruct = (*ItemIPv4)(nil)
+var _ ItemValue = (*ItemIPv4)(nil)
 
-// Reload implements ItemStruct interface.
-func (item *ItemIPv4) Reload() {
-	cptr := (*C.struct_rte_flow_item_ipv4)(item.createOrRet(C.sizeof_struct_rte_flow_item_ipv4))
-	cvtIPv4Header(&cptr.hdr, &item.Header)
-	runtime.SetFinalizer(item, (*ItemIPv4).free)
+// Transform implements Action interface.
+func (item *ItemIPv4) Transform(alloc common.Allocator) (unsafe.Pointer, func(unsafe.Pointer)) {
+	ptr := &C.struct_rte_flow_item_ipv4{}
+	ptr.hdr = *(*C.struct_rte_ipv4_hdr)(unsafe.Pointer(&item.Header))
+	return common.TransformPOD(alloc, ptr)
 }
 
-func cvtIPv4Header(dst *C.struct_rte_ipv4_hdr, src *IPv4Header) {
-	setIPv4HdrVersionIHL(dst, src)
-
-	dst.type_of_service = C.uint8_t(src.ToS)
-	beU16(src.TotalLength, unsafe.Pointer(&dst.total_length))
-	beU16(src.ID, unsafe.Pointer(&dst.packet_id))
-	beU16(src.FragmentOffset, unsafe.Pointer(&dst.fragment_offset))
-	dst.time_to_live = C.uint8_t(src.TTL)
-	dst.next_proto_id = C.uint8_t(src.Proto)
-	beU16(src.Checksum, unsafe.Pointer(&dst.hdr_checksum))
-
-	dst.src_addr = *(*C.rte_be32_t)(unsafe.Pointer(&src.SrcAddr[0]))
-	dst.dst_addr = *(*C.rte_be32_t)(unsafe.Pointer(&src.DstAddr[0]))
-}
-
-func setIPv4HdrVersionIHL(dst *C.struct_rte_ipv4_hdr, src *IPv4Header) {
-	p := off(unsafe.Pointer(dst), C.IPv4_HDR_OFF_DST_VERSION_IHL)
-	*(*C.uint8_t)(p) = (C.uchar)(src.VersionIHL)
-}
-
-// Type implements ItemStruct interface.
-func (item *ItemIPv4) Type() ItemType {
+// ItemType implements ItemValue interface.
+func (item *ItemIPv4) ItemType() ItemType {
 	return ItemTypeIPv4
 }
 
-// Mask implements ItemStruct interface.
-func (item *ItemIPv4) Mask() unsafe.Pointer {
-	return unsafe.Pointer(C.get_item_ipv4_mask())
+// DefaultMask implements ItemStruct interface.
+func (item *ItemIPv4) DefaultMask() unsafe.Pointer {
+	return unsafe.Pointer(&C.rte_flow_item_ipv4_mask)
 }

--- a/ethdev/flow/item_vlan.go
+++ b/ethdev/flow/item_vlan.go
@@ -10,10 +10,6 @@ enum {
 	ITEM_VLAN_OFF_HDR = offsetof(struct rte_flow_item_vlan, hdr),
 };
 
-static const void *get_item_vlan_mask() {
-	return &rte_flow_item_vlan_mask;
-}
-
 static void set_has_more_vlan(struct rte_flow_item_vlan *item, uint32_t d) {
 	item->has_more_vlan = d;
 }
@@ -21,11 +17,12 @@ static void set_has_more_vlan(struct rte_flow_item_vlan *item, uint32_t d) {
 */
 import "C"
 import (
-	"runtime"
 	"unsafe"
+
+	"github.com/yerden/go-dpdk/common"
 )
 
-var _ ItemStruct = (*ItemVlan)(nil)
+var _ ItemValue = (*ItemVlan)(nil)
 
 // ItemVlan matches an 802.1Q/ad VLAN tag.
 //
@@ -37,15 +34,14 @@ var _ ItemStruct = (*ItemVlan)(nil)
 // If the eth_proto of hdr and has_more_vlan fields are not specified, then any
 // tagged packets will match the pattern.
 type ItemVlan struct {
-	cPointer
 	HasMoreVlan bool
 	TCI         uint16
 	InnerType   uint16
 }
 
-// Reload implements ItemStruct interface.
-func (item *ItemVlan) Reload() {
-	cptr := (*C.struct_rte_flow_item_vlan)(item.createOrRet(C.sizeof_struct_rte_flow_item_vlan))
+// Transform implements Action interface.
+func (item *ItemVlan) Transform(alloc common.Allocator) (unsafe.Pointer, func(unsafe.Pointer)) {
+	cptr := &C.struct_rte_flow_item_vlan{}
 
 	if item.HasMoreVlan {
 		C.set_has_more_vlan(cptr, 1)
@@ -54,18 +50,17 @@ func (item *ItemVlan) Reload() {
 	}
 
 	hdr := (*C.struct_rte_vlan_hdr)(off(unsafe.Pointer(cptr), C.ITEM_VLAN_OFF_HDR))
-	beU16(item.TCI, unsafe.Pointer(&hdr.vlan_tci))
-	beU16(item.InnerType, unsafe.Pointer(&hdr.eth_proto))
-
-	runtime.SetFinalizer(item, (*ItemVlan).free)
+	hdr.vlan_tci = C.ushort(item.TCI)
+	hdr.eth_proto = C.ushort(item.InnerType)
+	return common.TransformPOD(alloc, cptr)
 }
 
-// Type implements ItemStruct interface.
-func (item *ItemVlan) Type() ItemType {
+// ItemType implements ItemValue interface.
+func (item *ItemVlan) ItemType() ItemType {
 	return ItemTypeVlan
 }
 
-// Mask implements ItemStruct interface.
-func (item *ItemVlan) Mask() unsafe.Pointer {
-	return C.get_item_vlan_mask()
+// DefaultMask implements ItemStruct interface.
+func (item *ItemVlan) DefaultMask() unsafe.Pointer {
+	return unsafe.Pointer(&C.rte_flow_item_vlan_mask)
 }

--- a/ethdev/flow/utils.go
+++ b/ethdev/flow/utils.go
@@ -33,25 +33,3 @@ func beU32(n uint32, p unsafe.Pointer) {
 	sh.Cap = sh.Len
 	binary.BigEndian.PutUint32(d, n)
 }
-
-type cPointer struct {
-	cptr unsafe.Pointer
-}
-
-func (p *cPointer) free() {
-	C.free(p.cptr)
-}
-
-// Pointer is the blanket implementation of ItemStruct/Action.
-func (p *cPointer) Pointer() unsafe.Pointer {
-	return p.cptr
-}
-
-func (p *cPointer) createOrRet(n C.ulong) unsafe.Pointer {
-	if p.cptr == nil {
-		p.cptr = C.malloc(n)
-		C.memset(p.cptr, 0, n)
-	}
-
-	return p.cptr
-}


### PR DESCRIPTION
use `common.Transformer` interface to redesign ethdev/flow (`rte_flow` wrapper).