### PR TITLE
eal: add PanicAsErr to handle panics

### DIFF
--- a/eal/eal_test.go
+++ b/eal/eal_test.go
@@ -58,6 +58,8 @@ func TestEALInit(t *testing.T) {
 	assert(myset == set)
 
 	// test panic
+	PanicAsErr = true
+
 	for _, id := range Lcores() {
 		err := ExecOnLcore(id, func(ctx *LcoreCtx) {
 			panic("emit panic")


### PR DESCRIPTION
Add `PanicAsErr` flag to change behavior on panics occurring in logical cores.